### PR TITLE
Fix batch file encoding

### DIFF
--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -1365,7 +1365,7 @@ namespace Microsoft.Build.Utilities
                     }
                     else
                     {
-                        File.AppendAllText(_temporaryBatchFile, commandLineCommands, Console.InputEncoding); // Or Ideally a new EncodingUtilities.CurrentConsoleEncoding
+                        File.AppendAllText(_temporaryBatchFile, commandLineCommands, Console.InputEncoding); // Or ideally a new EncodingUtilities.CurrentConsoleEncoding based on GetConsoleCP
 
                         string batchFileForCommandLine = _temporaryBatchFile;
 

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -1365,7 +1365,7 @@ namespace Microsoft.Build.Utilities
                     }
                     else
                     {
-                        File.AppendAllText(_temporaryBatchFile, commandLineCommands, EncodingUtilities.CurrentSystemOemEncoding);
+                        File.AppendAllText(_temporaryBatchFile, commandLineCommands, Console.InputEncoding); // Or Ideally a new EncodingUtilities.CurrentConsoleEncoding
 
                         string batchFileForCommandLine = _temporaryBatchFile;
 


### PR DESCRIPTION
MSBuild writes its batch files using the OEM codepage, but `cmd.exe` actually interprets it using the current console code page inherited from `MSBuild.exe`. By default, the console code page is equal to the OEM codepage, but it could have been changed by any ancestor process that caused MSBuild to run.